### PR TITLE
Updates for MPAS recentering

### DIFF
--- a/mpas_ensmean_recenter.fd/gen_ensmean_recenter.f90
+++ b/mpas_ensmean_recenter.fd/gen_ensmean_recenter.f90
@@ -36,8 +36,8 @@ program gen_be_ensmean
 
    integer :: totalnumvar
    character (len=20), allocatable  ::  tailist_all(:)
-   character (len=20), allocatable  ::  varlist_all(:)
-   character (len=20)    :: varname                       ! Variable to search for.
+   character (len=30), allocatable  ::  varlist_all(:)
+   character (len=30)    :: varname                       ! Variable to search for.
 
    ! === variables for mpi 
    integer                :: iret, mype, npe, mype1, orig_group, new_group, new_comm
@@ -109,7 +109,7 @@ program gen_be_ensmean
      totalnumvar=totalnumvar+numvar(k)
   enddo
   if(totalnumvar <=0) then
-     write(6,'(a)')'***ERROR***  varaible number is 0'
+     write(6,'(a)')'***ERROR***  variable number is 0'
      call mpi_abort(mpi_comm_world,99,iret)
      stop
   endif
@@ -154,7 +154,7 @@ program gen_be_ensmean
 ! find how many cores will be used
   num_cores=groupsize*numgroup
 
-! find how many iterations needed to cover all the varaibles
+! find how many iterations needed to cover all the variables
 !  num_iteration=totalnumvar/numgroup+1
 
 ! how to distribute variables to group and iteration

--- a/mpas_ensmean_recenter.fd/ncio_ensmean_recenter.f90
+++ b/mpas_ensmean_recenter.fd/ncio_ensmean_recenter.f90
@@ -194,7 +194,10 @@ subroutine ncio_ensmean_recenter(ensize,mype,new_comm,l_write_mean,l_recenter,va
 
    if(l_recenter) then
       l_positive=.false.
-      if( trim(varname)=="ref_f3d" .or. trim(varname)=="qv" .or. trim(varname)=="q2" ) then 
+      if( trim(varname)=="ref_f3d" .or. trim(varname)=="qv" .or. trim(varname)=="q2" .or. &
+          trim(varname)=="qc" .or. trim(varname)=="qr" .or. trim(varname)=="qi" .or. &
+          trim(varname)=="qs" .or. trim(varname)=="qg" .or. trim(varname)=="ni" .or. &
+          trim(varname)=="nr" .or. trim(varname)=="ng" .or. trim(varname)=="nc") then 
          l_positive=.true.
       endif
       if(mype==0) then


### PR DESCRIPTION
This PR includes a couple of fixes needed for running recentering for MPAS: 

1. The `varname` string is increased to `len=30` so that it can include `uReconstructMeridional`
2. More hydrometeors are added to the if-check for `l_positive`. This is block that sets a minimum threshold of zero. Without this fix, recentering results in negative values for `qc`, `qr`, `qi`, etc. 

I tested these changes in rrfs-workflow and they work as expected. 